### PR TITLE
add udp example

### DIFF
--- a/examples/udp/udp-group-listener.clj
+++ b/examples/udp/udp-group-listener.clj
@@ -1,0 +1,33 @@
+;; Copyright 2013 the original author or authors.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;      http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns example.udp.udp-group-listener
+  (:require [vertx.core :as vertx]
+            [vertx.datagram :as udp]
+            [vertx.stream :as stream]))
+
+(let [peer (udp/socket)]
+  (udp/listen peer "127.0.0.1" 1234
+              (fn [err _]
+                
+                (udp/listen-multicast-group peer "230.0.0.1"
+                                            (fn [err _]
+                                              (stream/on-data peer
+                                                              (fn [packet]
+                                                                (let [data (udp/data packet)
+                                                                      sender (udp/sender packet)
+                                                                      info (format "Receive group packet %s, from host: %s port: %s"
+                                                                                   data (:host sender) (:port sender))]
+                                                                  (println info)))))
+                                            ))))

--- a/examples/udp/udp-group-sender.clj
+++ b/examples/udp/udp-group-sender.clj
@@ -1,0 +1,27 @@
+;; Copyright 2013 the original author or authors.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;      http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns example.udp.udp-group-sender
+  (:require [vertx.core :as vertx]
+            [vertx.datagram :as udp]))
+
+(let [peer (udp/socket)]
+  (doseq [i (range 10)]
+    (let [s (format "hello %s\n" i)]
+      (udp/send peer "group-data" "230.0.0.1" 1234
+                (fn [err _]
+                  (if (nil? err)
+                    (println "send group packet:" s)
+                    (println (.getMessage err)))))
+      )))

--- a/examples/udp/udp-listener.clj
+++ b/examples/udp/udp-listener.clj
@@ -1,0 +1,29 @@
+;; Copyright 2013 the original author or authors.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;      http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns example.udp.udp-listener
+  (:require [vertx.core :as vertx]
+            [vertx.datagram :as udp]
+            [vertx.stream :as stream]))
+
+(let [peer (udp/socket)]
+  (udp/listen peer "127.0.0.1" 1234
+              (fn [err _]
+                (stream/on-data peer
+                                (fn [packet]
+                                  (let [data (udp/data packet)
+                                        sender (udp/sender packet)
+                                        info (format "Receive packet %s, from host: %s port: %s"
+                                                     data (:host sender) (:port sender))]
+                                    (println info)))))))

--- a/examples/udp/udp-sender.clj
+++ b/examples/udp/udp-sender.clj
@@ -1,0 +1,28 @@
+;; Copyright 2013 the original author or authors.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;      http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns example.udp.udp-sender
+  (:require [vertx.core :as vertx]
+            [vertx.datagram :as udp]))
+
+(let [peer (udp/socket)]
+  (doseq [i (range 10)]
+    (let [s (format "hello %s\n" i)]
+      (udp/send peer "data" "127.0.0.1" 1234
+                (fn [err _]
+                  (if (nil? err)
+                    (println "send packet:" s)
+                    (println (.getMessage err)))))
+      ))
+  )


### PR DESCRIPTION
Hi 
i try to add some example of udp follow document in http://vertx.io/core_manual_java.html#user-datagram-protocol-udp

but the part of group is not work as i wanted, could you take a moment to work out?
thanks..
